### PR TITLE
Optimize

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,3 +41,6 @@ jobs:
           pip install pytest
           pip install pytest-cov
           pytest --ignore=docs_src/ --cov=./
+        env: 
+          ALPACA_PAPER_API_KEY: ${{ secrets.ALPACA_PAPER_API_KEY}}
+          ALPACA_PAPER_API_SECRET: ${{ secrets.ALPACA_PAPER_API_SECRET}}

--- a/README.md
+++ b/README.md
@@ -8,11 +8,22 @@ To do that, it provides tools for constructing and managing portfolios that are 
 portfolios can be efficiently converted into actual portfolios by API, using commission free platforms like Robinhood or Alpaca. Since constructing an index analogue typically requires many small stock purchases, a
 commission free platform is important to minimizing overhead. For small investment sizes, the ability of the platform to support fractional shares is critical to being able to accurately map to the index.
 
+## Indexes
+
+py-portfolio-index contains a default set of indexes, which can be access via the INDEXES dictionary: `from py_portfolio_index import INDEXES`. These indexes are based on the common industry index cuts such as 
+Large Cap or real-estate and are updated quarterly.
+
+## Lists/Themes
+
+py-portfolio-index also contains a default list of stock lists, which can be access via the STOCK_LISTS dictionary: `from py_portfolio_index import STOCK_LISTS`. These lists are thematic groupings, such as by industry (space)
+or by other criteria (vice). Lists can be applied to modify indexes or reweight them to create customized
+portfolios. 
+
 #### Install
 
-The package supports Python 3.7 plus.
+The package supports Python 3.9 plus.
 
-`pip install py-portfolio-index` [Not yet!]
+`pip install py-portfolio-index`
 
 #### Considerations
 

--- a/py_portfolio_index/__init__.py
+++ b/py_portfolio_index/__init__.py
@@ -16,7 +16,7 @@ from py_portfolio_index.config import get_providers
 
 AVAILABLE_PROVIDERS = get_providers()
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 
 __all__ = [
     "INDEXES",

--- a/py_portfolio_index/models.py
+++ b/py_portfolio_index/models.py
@@ -306,7 +306,7 @@ class RealPortfolio(BaseModel):
         for item in self.holdings:
             item.weight = Decimal(item.value.value / value.value)
 
-    def add_holding(self, holding: RealPortfolioElement, reweight:bool = True):
+    def add_holding(self, holding: RealPortfolioElement, reweight: bool = True):
         existing = self._index.get(holding.ticker)
         if existing:
             existing.value += holding.value

--- a/py_portfolio_index/models.py
+++ b/py_portfolio_index/models.py
@@ -306,7 +306,7 @@ class RealPortfolio(BaseModel):
         for item in self.holdings:
             item.weight = Decimal(item.value.value / value.value)
 
-    def add_holding(self, holding: RealPortfolioElement):
+    def add_holding(self, holding: RealPortfolioElement, reweight:bool = True):
         existing = self._index.get(holding.ticker)
         if existing:
             existing.value += holding.value
@@ -321,14 +321,16 @@ class RealPortfolio(BaseModel):
                     unsettled=False,
                 )
             )
-        self._reweight_portfolio()
+        if reweight:
+            self._reweight_portfolio()
 
     def __add__(self, other):
         if isinstance(other, RealPortfolioElement):
             self.add_holding(other)
         elif isinstance(other, RealPortfolio):
             for item in other.holdings:
-                self.add_holding(item)
+                self.add_holding(item, reweight=False)
+            self._reweight_portfolio()
         else:
             raise ValueError
         return self

--- a/py_portfolio_index/portfolio_providers/common.py
+++ b/py_portfolio_index/portfolio_providers/common.py
@@ -10,7 +10,6 @@ from datetime import date as datetype
 
 
 class PriceCache(object):
-
     def __init__(self, fetcher):
         self.fetcher = fetcher
         self.store = defaultdict(dict)

--- a/py_portfolio_index/portfolio_providers/common.py
+++ b/py_portfolio_index/portfolio_providers/common.py
@@ -1,0 +1,29 @@
+# Class implementing a cache
+# for historic stock prices
+# requires a callable interace to get values at date for a list of tickers
+# accepts list of stocks + dates to get values for
+# returns these from cache if possible, or for those not found
+# calls provider to return prices
+from collections import defaultdict
+from typing import List
+from datetime import date as datetype
+
+
+class PriceCache(object):
+
+    def __init__(self, fetcher):
+        self.fetcher = fetcher
+        self.store = defaultdict(dict)
+
+    def get_prices(self, tickers: List[str], date: datetype | None):
+        if not date:
+            date = datetype.today()
+        cached = self.store[date]
+        found = {k: v for k, v in cached.items() if k in tickers}
+        missing = [x for x in tickers if x not in cached]
+        if missing:
+            prices = self.fetcher(missing, date)
+            for ticker, price in prices.items():
+                cached[ticker] = price
+                found[ticker] = price
+        return found

--- a/py_portfolio_index/portfolio_providers/robinhood.py
+++ b/py_portfolio_index/portfolio_providers/robinhood.py
@@ -2,11 +2,15 @@ import re
 from decimal import Decimal
 from time import sleep
 from datetime import date, datetime
-from typing import Optional, List, Dict, Set
+from typing import Optional, List, Dict, DefaultDict
 from py_portfolio_index.constants import Logger
 from py_portfolio_index.models import RealPortfolio, RealPortfolioElement, Money
 from py_portfolio_index.common import divide_into_batches
-from py_portfolio_index.portfolio_providers.base_portfolio import BaseProvider
+from py_portfolio_index.portfolio_providers.common import PriceCache
+from py_portfolio_index.portfolio_providers.base_portfolio import (
+    BaseProvider,
+    CacheKey,
+)
 from py_portfolio_index.exceptions import PriceFetchError, ConfigurationError
 from py_portfolio_index.portfolio_providers.helpers.robinhood import (
     validate_login,
@@ -56,10 +60,8 @@ def nearest_multi_value(
 
 
 class RobinhoodProvider(BaseProvider):
-    """Provider for interacting with Robinhood portfolios.
-
-    Requires username and password.
-
+    """Provider for interacting with stocks held in
+    Robinhood.
     """
 
     PROVIDER = Provider.ROBINHOOD
@@ -92,12 +94,17 @@ class RobinhoodProvider(BaseProvider):
         if not skip_cache:
             self._load_local_instrument_cache()
         self._local_latest_price_cache: Dict[str, Decimal] = {}
+        self._price_cache: PriceCache = PriceCache(fetcher=self._get_instrument_prices)
 
     @property
-    def valid_assets(self) -> Set[str]:
+    def valid_assets(self) -> set[str]:
         if not self._local_instrument_cache:
             self._load_local_instrument_cache()
-        return {row["symbol"] for row in self._local_instrument_cache}
+        return self._get_cached_value(
+            CacheKey.MISC,
+            value="valid_tickers",
+            callable=lambda: {row["symbol"] for row in self._local_instrument_cache},
+        )
 
     def _load_local_instrument_cache(self):
         from platformdirs import user_cache_dir
@@ -152,7 +159,6 @@ class RobinhoodProvider(BaseProvider):
     ) -> dict:
         """Custom function to enable evolution with the robinhood API"""
         from robin_stocks.robinhood.stocks import (
-            get_instruments_by_symbols,
             orders_url,
             request_post,
         )
@@ -168,9 +174,22 @@ class RobinhoodProvider(BaseProvider):
         )
         if value:
             qty = round(float(value.decimal) / price, 2)
+
+        account = self._get_cached_value(
+            CacheKey.MISC,
+            value="account_id",
+            callable=lambda: load_account_profile(account_number=None, info="id")[0],
+        )
+        sym_to_i = self._get_cached_value(
+            CacheKey.MISC,
+            value="symbol_to_instrument",
+            callable=lambda: {
+                row["symbol"]: row["instrument"] for row in self._local_instrument_cache
+            },
+        )
         payload = {
-            "account": load_account_profile(account_number=None, info="url"),
-            "instrument": get_instruments_by_symbols(symbol, info="url")[0],
+            "account": account,
+            "instrument": sym_to_i[symbol],
             "order_form_version": "2",
             "preset_percent_limit": "0.05",
             "symbol": symbol,
@@ -216,16 +235,19 @@ class RobinhoodProvider(BaseProvider):
         return True
 
     def get_unsettled_instruments(self) -> set[str]:
+        from robin_stocks.robinhood.orders import orders_url, request_get
+
         """We need to efficiently bypass
         paginating all orders if possible
         so just check the account info for if there
         is any cash held for orders first"""
-        accounts_data = self._provider.load_account_profile()
+        accounts_data = self._get_cached_value(
+            CacheKey.ACCOUNT, callable=self._provider.load_account_profile
+        )
         if not accounts_data:
             raise ConfigurationError("Could not load account profile, check login")
         if float(accounts_data.get("cash_held_for_orders", 0)) == 0:
             return set()
-        from robin_stocks.robinhood.orders import orders_url, request_get
 
         url = orders_url()
         from datetime import datetime, timedelta
@@ -252,20 +274,35 @@ class RobinhoodProvider(BaseProvider):
         instrument_info = request_get(instrument_url, dataType="pagination")
         self._local_instrument_cache = instrument_info
         self._save_local_instrument_cache()
+        return self._local_instrument_cache
+
+    def _process_cache_to_dict(self):
+        return {row["url"]: row["symbol"] for row in self._local_instrument_cache}
 
     def _get_local_instrument_symbol(
         self, instrument: str, refreshed: bool = False
     ) -> str:
         if not self._local_instrument_cache:
             self._refresh_local_instruments()
-        instrument_to_symbol_map = {
-            row["url"]: row["symbol"] for row in self._local_instrument_cache
-        }
+
+        instrument_to_symbol_map = self._get_cached_value(
+            CacheKey.MISC,
+            value="instrument_to_symbol_map",
+            callable=self._process_cache_to_dict,
+        )
         try:
-            return instrument_to_symbol_map[instrument]
+            out = instrument_to_symbol_map[instrument]
+            return out
         except KeyError as e:
             if not refreshed:
                 self._refresh_local_instruments()
+                instrument_to_symbol_map = self._get_cached_value(
+                    CacheKey.MISC,
+                    value="instrument_to_symbol_map",
+                    callable=self._process_cache_to_dict,
+                    # force refresh
+                    max_age_seconds=1,
+                )
                 return self._get_local_instrument_symbol(instrument, True)
             raise e
 
@@ -283,19 +320,29 @@ class RobinhoodProvider(BaseProvider):
         return {}
 
     def get_holdings(self):
-        accounts_data = self._provider.load_account_profile()
-        my_stocks = self._provider.get_open_stock_positions()
-        unsettled = self.get_unsettled_instruments()
+        accounts_data = self._get_cached_value(
+            CacheKey.ACCOUNT, callable=self._provider.load_account_profile
+        )
+        my_stocks = self._get_cached_value(
+            CacheKey.POSITIONS, callable=self._provider.get_open_stock_positions
+        )
+        unsettled = self._get_cached_value(
+            CacheKey.UNSETTLED, callable=self.get_unsettled_instruments
+        )
         if not self._local_instrument_cache:
             self._refresh_local_instruments()
 
         pre = {}
         symbols = []
+        instrument_to_symbol_map = self._get_cached_value(
+            CacheKey.MISC,
+            callable=self._process_cache_to_dict,
+        )
         for row in my_stocks:
             local = {}
             local["units"] = row["quantity"]
             # instrument_data = self._provider.get_instrument_by_url(row["instrument"])
-            ticker = self._get_local_instrument_symbol(row["instrument"])
+            ticker = instrument_to_symbol_map[row["instrument"]]
             local["ticker"] = ticker
             symbols.append(ticker)
             local["value"] = 0
@@ -332,7 +379,10 @@ class RobinhoodProvider(BaseProvider):
         )
         return RealPortfolio(holdings=out, cash=Money(value=cash), provider=self)
 
-    def get_instrument_prices(
+    def get_instrument_prices(self, tickers: List[str], at_day: Optional[date] = None):
+        return self._price_cache.get_prices(tickers=tickers, date=at_day)
+
+    def _get_instrument_prices(
         self, tickers: List[str], at_day: Optional[date] = None
     ) -> Dict[str, Optional[Decimal]]:
         ticker_list = tickers
@@ -354,22 +404,45 @@ class RobinhoodProvider(BaseProvider):
         return prices
 
     def get_profit_or_loss(self, include_dividends: bool = True) -> Money:
-        my_stocks = self._provider.get_open_stock_positions()
-        pls = []
+        my_stocks = self._get_cached_value(
+            CacheKey.POSITIONS, callable=self._provider.get_open_stock_positions
+        )
+        pls: List[Money] = []
+        instrument_to_symbol_map = self._get_cached_value(
+            CacheKey.MISC,
+            callable=self._process_cache_to_dict,
+        )
         for x in my_stocks:
             historical_value = Decimal(x["average_buy_price"]) * Decimal(x["quantity"])
-            ticker = self._get_local_instrument_symbol(x["instrument"])
+            ticker = instrument_to_symbol_map[x["instrument"]]
             try:
                 current_price = self.get_instrument_price(ticker) or Decimal(0.0)
             except PriceFetchError:
                 current_price = Decimal(0.0)
             current_value = current_price * Decimal(x["quantity"])
-            pl = current_value - historical_value
+            pl = Money(value=current_value - historical_value)
             pls.append(pl)
         _total_pl = sum(pls)  # type: ignore
         if not include_dividends:
             return Money(value=_total_pl)
-        return Money(value=_total_pl) + self._get_dividends()
+        return Money(value=_total_pl) + sum(self._get_dividends().values())
 
-    def _get_dividends(self) -> Money:
-        return Money(value=self._provider.get_total_dividends())
+    def _get_dividends(self) -> DefaultDict[str, Money]:
+        from collections import defaultdict
+
+        value = self._get_cached_value(
+            CacheKey.DIVIDENDS, callable=self._provider.get_dividends
+        )
+        output: DefaultDict[str, Money] = defaultdict(lambda: Money(value=0))
+        instrument_to_symbol_map = self._get_cached_value(
+            CacheKey.MISC,
+            callable=self._process_cache_to_dict,
+        )
+        [
+            item.update({"symbol": instrument_to_symbol_map[item["instrument"]]})
+            for item in value
+        ]
+        for item in value:
+            if item["state"] == "paid":
+                output[item["symbol"]] += Money(value=float(item["amount"]))
+        return output

--- a/py_portfolio_index/portfolio_providers/robinhood.py
+++ b/py_portfolio_index/portfolio_providers/robinhood.py
@@ -178,13 +178,13 @@ class RobinhoodProvider(BaseProvider):
         account = self._get_cached_value(
             CacheKey.MISC,
             value="account_id",
-            callable=lambda: load_account_profile(account_number=None, info="id")[0],
+            callable=lambda: load_account_profile(account_number=None, info="url"),
         )
         sym_to_i = self._get_cached_value(
             CacheKey.MISC,
             value="symbol_to_instrument",
             callable=lambda: {
-                row["symbol"]: row["instrument"] for row in self._local_instrument_cache
+                row["symbol"]: row["url"] for row in self._local_instrument_cache
             },
         )
         payload = {
@@ -230,8 +230,11 @@ class RobinhoodProvider(BaseProvider):
             sleep(FRACTIONAL_SLEEP)
             output = self.buy_instrument(ticker=ticker, qty=qty)
         if not output.get("id"):
-            Logger.error(msg)
-            raise ValueError(msg)
+            if msg:
+                Logger.error(msg)
+                raise ValueError(msg)
+            Logger.error(output)
+            raise ValueError(output)
         return True
 
     def get_unsettled_instruments(self) -> set[str]:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ mypy
 ruff
 requests
 types-requests
+alpaca-py

--- a/tests_integration/test_integration.py
+++ b/tests_integration/test_integration.py
@@ -1,0 +1,18 @@
+from py_portfolio_index import PaperAlpacaProvider
+
+
+def test_provider_methods():
+    providers = [PaperAlpacaProvider()]
+    # if "robinhood" in AVAILABLE_PROVIDERS:
+    #     providers.append(RobinhoodProvider())
+
+    for provider in providers:
+        provider.get_holdings()
+        real_ticker = "MSFT"
+        p1 = provider.get_instrument_price(real_ticker)
+        p2 = provider.get_instrument_prices([real_ticker])
+        assert p1 == p2[real_ticker]
+
+        provider.get_unsettled_instruments()
+
+        provider.get_stock_info(real_ticker)


### PR DESCRIPTION
Introduce performance optimizations across both providers, but primarily RH. Include time-boxed caching, historical price cache, etc. This may require users to manually clear cache more often for some use cases. 

Other perf fixes
- Reducing excessive rebalancing when merging portfolios
- avoid recreating maps on several occasions